### PR TITLE
Update to new version of Facebook API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
   - '5.6'
   - '7.0'
   - hhvm
-  - nightly
+
+dist: trusty
 
 before_script:
   # Disable xdebug for speed.

--- a/Api/AbstractClient.php
+++ b/Api/AbstractClient.php
@@ -6,7 +6,7 @@ use FacebookAds\Api;
 
 abstract class AbstractClient
 {
-    const GRAPH_VERSION = 'v2.7';
+    const GRAPH_VERSION = 'v2.8';
 
     /**
      * @var int

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": ">=5.3.2",
     "symfony/framework-bundle": "~2.3|~3.0",
     "facebook/php-sdk-v4" : "~5.2",
-    "facebook/php-ads-sdk": "2.7.*",
+    "facebook/php-ads-sdk": "2.8.*",
     "werkspot/enum": "dev-master"
   },
   "require-dev": {


### PR DESCRIPTION
Due to the depreciation of Facebooks API we need to update to version 2.8